### PR TITLE
feat: Backend setup + Supabase schema (closes #1, #2)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,13 +1,30 @@
+# ============================================================
+# MindProtocol — Environment Variables Template
+# Copy this file to .env and fill in your real values.
+# NEVER commit .env to GitHub — it's in .gitignore already.
+# Owner: Nishant | Share this template on Day 0 with the team.
+# ============================================================
 
-# Copy this file, rename it to .env, and fill in your real values
-# NEVER commit the actual .env file
+# ------ Supabase ------
+# Found in: Supabase Dashboard → Settings → API
+SUPABASE_URL=https://your-project-ref.supabase.co
+SUPABASE_ANON_KEY=your_anon_key_here
+SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
 
-# Groq API (get free key at console.groq.com)
+# Found in: Supabase Dashboard → Settings → API → JWT Settings
+SUPABASE_JWT_SECRET=your_jwt_secret_here
+
+# ------ Groq (Sujan fills this in) ------
+# Get from: console.groq.com → API Keys (free, no card)
 GROQ_API_KEY=your_groq_api_key_here
 
-# Supabase (get from your Supabase project settings)
-SUPABASE_URL=your_supabase_project_url_here
-SUPABASE_KEY=your_supabase_anon_key_here
+# ------ HuggingFace (Sujan fills this in) ------
+# Get from: huggingface.co → Settings → Access Tokens (free)
+HUGGINGFACE_API_TOKEN=your_hf_token_here
 
-# HuggingFace (get free token at huggingface.co/settings/tokens)
-HUGGINGFACE_TOKEN=your_huggingface_token_here
+# ------ App Config ------
+APP_ENV=development
+
+# Comma-separated list of allowed CORS origins
+# Bidhur: add your Expo dev URL here once you have it
+ALLOWED_ORIGINS=http://localhost:19006,exp://192.168.1.x:8081

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,31 @@
+# Environment — NEVER commit real secrets
+.env
+*.env
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+.Python
+*.egg-info/
+dist/
+build/
+*.egg
+.eggs/
+venv/
+.venv/
+env/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,103 @@
+"""
+main.py
+--------
+MindProtocol FastAPI application entry point.
+
+To run locally:
+    uvicorn main:app --reload --port 8000
+
+To run on Railway (production):
+    uvicorn main:app --host 0.0.0.0 --port $PORT
+
+Interactive API docs (development only):
+    http://localhost:8000/docs   ← Swagger UI
+    http://localhost:8000/redoc  ← ReDoc
+
+Owner: Nishant
+"""
+
+import os
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from dotenv import load_dotenv
+
+from routers import auth, morning, evening, weekly
+from services.supabase_client import supabase_admin
+
+load_dotenv()
+
+
+# ── Startup / Shutdown ─────────────────────────────────────
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """
+    Runs once on startup to verify the Supabase connection is healthy.
+    If this fails, the server still starts — it just logs a warning.
+    """
+    print("🧠 MindProtocol API starting up...")
+    try:
+        # Simple connectivity test — count rows in profiles (RLS-safe)
+        supabase_admin.table("profiles").select("id", count="exact").limit(1).execute()
+        print("✅ Supabase connection: OK")
+    except Exception as e:
+        print(f"⚠️  Supabase connection check failed: {e}")
+        print("   Server will start anyway — check your .env credentials.")
+
+    yield  # App runs here
+
+    print("🧠 MindProtocol API shutting down.")
+
+
+# ── App Initialization ─────────────────────────────────────
+
+app = FastAPI(
+    title="MindProtocol API",
+    version="1.0.0",
+    description=(
+        "Backend API for MindProtocol — a science-backed daily mental health "
+        "companion. Nepal-US Hackathon 2026.\n\n"
+        "**Owner:** Nishant (Backend, Database & ML Logic)\n"
+        "**Stack:** FastAPI + Supabase + Groq (llama-3.3-70b)"
+    ),
+    lifespan=lifespan,
+    # Disable docs in production to avoid exposing the API surface
+    docs_url="/docs" if os.getenv("APP_ENV") != "production" else None,
+    redoc_url="/redoc" if os.getenv("APP_ENV") != "production" else None,
+)
+
+
+# ── CORS ───────────────────────────────────────────────────
+# Bidhur: add your Expo dev URL to ALLOWED_ORIGINS in .env
+
+_raw_origins = os.getenv("ALLOWED_ORIGINS", "http://localhost:19006")
+allowed_origins = [origin.strip() for origin in _raw_origins.split(",")]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=allowed_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+# ── Routers ────────────────────────────────────────────────
+
+app.include_router(auth.router,    prefix="")           # /auth/register, /auth/login
+app.include_router(morning.router, prefix="")           # /morning-checkin
+app.include_router(evening.router, prefix="")           # /evening-response
+app.include_router(weekly.router,  prefix="")           # /weekly-summary
+
+
+# ── Health Check ───────────────────────────────────────────
+
+@app.get("/", tags=["Health"])
+async def health_check():
+    """
+    Health check endpoint.
+    Railway uses this to confirm the app is live after deployment.
+    Bidhur: ping this first to confirm the backend URL is reachable.
+    """
+    return {"status": "ok", "project": "MindProtocol"}

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,0 +1,1 @@
+# models package

--- a/backend/models/evening.py
+++ b/backend/models/evening.py
@@ -1,0 +1,75 @@
+"""
+models/evening.py
+------------------
+Pydantic v2 models for the /evening-response endpoint.
+
+This endpoint handles two distinct steps via the "step" discriminator field:
+  - "generate_questions"  : Step 1 — fetch morning context, generate 3 questions
+  - "submit_answers"      : Step 2 — save answers, get AI reframe
+
+Bidhur: Call Step 1 when the user opens the evening journal screen.
+        Call Step 2 after the user answers all 3 questions.
+"""
+
+from pydantic import BaseModel, Field
+from typing import Literal, Optional
+
+
+# ── STEP 1: Generate questions ─────────────────────────────
+
+class GenerateQuestionsRequest(BaseModel):
+    """Request body for Step 1 of POST /evening-response."""
+
+    step: Literal["generate_questions"]
+    morning_session_id: str = Field(
+        description="UUID of today's morning session (from /morning-checkin response)",
+        json_schema_extra={"example": "550e8400-e29b-41d4-a716-446655440000"},
+    )
+
+
+class EveningQuestions(BaseModel):
+    """The 3 AI-generated questions."""
+    q1: str
+    q2: str
+    q3: str
+
+
+class GenerateQuestionsResponse(BaseModel):
+    """Response for Step 1."""
+    evening_session_id: str = Field(description="UUID of the created evening session")
+    questions: EveningQuestions
+
+
+# ── STEP 2: Submit answers + get reframe ───────────────────
+
+class SubmitAnswersRequest(BaseModel):
+    """Request body for Step 2 of POST /evening-response."""
+
+    step: Literal["submit_answers"]
+    evening_session_id: str = Field(
+        description="UUID of the evening session from Step 1",
+    )
+    q1_answer: str = Field(max_length=2000)
+    q2_answer: str = Field(max_length=2000)
+    q3_answer: str = Field(max_length=2000)
+
+
+class ReframeResponse(BaseModel):
+    """The 3-part AI reframe returned after Step 2."""
+    acknowledgment: str = Field(description="Validates the user's experience")
+    insight: str = Field(description="Gentle observation or reframe")
+    invitation: str = Field(description="Micro-action or intention for tomorrow")
+
+
+class SubmitAnswersResponse(BaseModel):
+    """Response for Step 2."""
+    reframe_response: ReframeResponse
+    crisis_detected: bool = Field(
+        description="True if crisis signals detected — frontend shows help resources"
+    )
+
+
+# ── Union type for the router ───────────────────────────────
+# FastAPI will try GenerateQuestionsRequest first, then SubmitAnswersRequest
+from typing import Union
+EveningRequest = Union[GenerateQuestionsRequest, SubmitAnswersRequest]

--- a/backend/models/morning.py
+++ b/backend/models/morning.py
@@ -1,0 +1,58 @@
+"""
+models/morning.py
+------------------
+Pydantic v2 models for the /morning-checkin endpoint.
+
+Bidhur: The frontend should send a POST body matching MorningCheckinRequest.
+        The response will match MorningCheckinResponse.
+"""
+
+from pydantic import BaseModel, Field
+from typing import Optional
+
+
+class MorningCheckinRequest(BaseModel):
+    """
+    Validated request body for POST /morning-checkin.
+    FastAPI will return 422 automatically if any field is invalid.
+    """
+
+    sleep_score: int = Field(
+        ...,
+        ge=0, le=10,
+        description="Sleep quality score from 0 (terrible) to 10 (excellent)",
+        json_schema_extra={"example": 6},
+    )
+    mood_score: int = Field(
+        ...,
+        ge=0, le=10,
+        description="Mood score from 0 (very low) to 10 (excellent)",
+        json_schema_extra={"example": 4},
+    )
+    stress_score: int = Field(
+        ...,
+        ge=0, le=10,
+        description="Stress level from 0 (none) to 10 (extreme)",
+        json_schema_extra={"example": 8},
+    )
+    exercise_done: bool = Field(
+        default=False,
+        description="Whether the user exercised this morning",
+    )
+    open_text: Optional[str] = Field(
+        default=None,
+        max_length=1000,
+        description="Optional free-text describing today's context",
+        json_schema_extra={"example": "I have a big exam today and I'm really anxious"},
+    )
+
+
+class MorningCheckinResponse(BaseModel):
+    """Response returned after a successful morning check-in."""
+
+    morning_session_id: str = Field(description="UUID of the created morning session")
+    state_flag: str = Field(
+        description="HIGH_REACTIVITY | LOW_BASELINE | PHYSICAL_DEPLETION | STABLE"
+    )
+    event_tag: str = Field(description="EVENT_TRIGGER | GENERAL_STATE")
+    message: str = Field(default="Morning check-in recorded. See you this evening.")

--- a/backend/models/weekly.py
+++ b/backend/models/weekly.py
@@ -1,0 +1,35 @@
+"""
+models/weekly.py
+-----------------
+Pydantic v2 models for the GET /weekly-summary endpoint.
+
+Danish: The "trend" field maps directly to your adaptive engine output:
+  - "IMPROVING"  → green indicator on the dashboard
+  - "FLAT"       → yellow indicator
+  - "DECLINING"  → red indicator (may also trigger Sujan's crisis logic)
+"""
+
+from pydantic import BaseModel, Field
+from typing import Literal, Optional
+
+
+class AverageScores(BaseModel):
+    """Average morning scores across the logged days this week."""
+    mood: float = Field(description="Average mood score (0–10)")
+    sleep: float = Field(description="Average sleep score (0–10)")
+    stress: float = Field(description="Average stress score (0–10)")
+
+
+class WeeklySummaryResponse(BaseModel):
+    """Response for GET /weekly-summary."""
+
+    week_summary: str = Field(
+        description="AI-generated 2–3 sentence paragraph summarizing weekly themes"
+    )
+    trend: Literal["IMPROVING", "DECLINING", "FLAT"] = Field(
+        description="Computed by detect_trend() from state_classifier.py"
+    )
+    days_logged: int = Field(
+        description="Number of days with at least one session this week (max 7)"
+    )
+    average_scores: AverageScores

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,10 @@
+fastapi==0.111.0
+uvicorn[standard]==0.29.0
+supabase==2.4.6
+python-dotenv==1.0.1
+pydantic==2.7.1
+httpx==0.27.0
+python-jose[cryptography]==3.3.0
+groq==0.9.0
+langchain==0.2.0
+langchain-community==0.2.0

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,0 +1,1 @@
+# routers package

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,0 +1,153 @@
+"""
+routers/auth.py
+----------------
+Authentication endpoints using Supabase Auth.
+
+Endpoints:
+  POST /auth/register  — Create a new user account
+  POST /auth/login     — Log in and receive a JWT access token
+  POST /auth/logout    — Invalidate the current session
+
+── BIDHUR (Frontend Contract) ────────────────────────────────────────
+Register:
+  Fetch: POST /auth/register
+  Body:  { email, password, username }
+  On 201: navigate to "email verification pending" screen
+
+Login:
+  Fetch: POST /auth/login
+  Body:  { email, password }
+  On 200: store access_token in SecureStore (Expo), store user_id
+  Include token in all subsequent requests:
+    headers: { Authorization: `Bearer ${access_token}` }
+
+Logout:
+  Fetch: POST /auth/logout
+  Headers: { Authorization: Bearer <token> }
+  On 200: clear token from SecureStore, navigate to login screen
+──────────────────────────────────────────────────────────────────────
+"""
+
+from fastapi import APIRouter, HTTPException, status, Depends
+from pydantic import BaseModel, EmailStr, Field
+from services.supabase_client import supabase
+from utils.auth_middleware import get_current_user
+
+router = APIRouter(prefix="/auth", tags=["Authentication"])
+
+
+# ── Request / Response models ──────────────────────────────
+
+class RegisterRequest(BaseModel):
+    email: EmailStr
+    password: str = Field(min_length=8)
+    username: str = Field(min_length=2, max_length=50)
+
+
+class RegisterResponse(BaseModel):
+    user_id: str
+    email: str
+    message: str
+
+
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class LoginResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    user_id: str
+
+
+# ── Endpoints ──────────────────────────────────────────────
+
+@router.post("/register", response_model=RegisterResponse, status_code=status.HTTP_201_CREATED)
+async def register(data: RegisterRequest):
+    """
+    Create a new MindProtocol account via Supabase Auth.
+
+    Supabase automatically triggers the on_auth_user_created trigger
+    which inserts a corresponding row into the public.profiles table
+    with the username from user_metadata.
+
+    The user will receive a confirmation email before they can log in
+    (Supabase email verification is enabled by default).
+    """
+    try:
+        result = supabase.auth.sign_up({
+            "email": data.email,
+            "password": data.password,
+            "options": {
+                # Stored in auth.users.raw_user_meta_data
+                # The trigger reads this to populate profiles.username
+                "data": {"username": data.username}
+            }
+        })
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Registration failed: {str(e)}",
+        )
+
+    if result.user is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Registration failed. The email may already be in use.",
+        )
+
+    return RegisterResponse(
+        user_id=str(result.user.id),
+        email=result.user.email,
+        message="Registration successful. Please verify your email.",
+    )
+
+
+@router.post("/login", response_model=LoginResponse, status_code=status.HTTP_200_OK)
+async def login(data: LoginRequest):
+    """
+    Authenticate a user and return a Supabase JWT access token.
+
+    The access_token must be included in the Authorization header of
+    all subsequent requests:
+        Authorization: Bearer <access_token>
+    """
+    try:
+        result = supabase.auth.sign_in_with_password({
+            "email": data.email,
+            "password": data.password,
+        })
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"Login failed: {str(e)}",
+        )
+
+    if result.session is None or result.user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid email or password.",
+        )
+
+    return LoginResponse(
+        access_token=result.session.access_token,
+        token_type="bearer",
+        user_id=str(result.user.id),
+    )
+
+
+@router.post("/logout", status_code=status.HTTP_200_OK)
+async def logout(user_id: str = Depends(get_current_user)):
+    """
+    Sign the current user out and invalidate their Supabase session.
+
+    The frontend should clear the token from local storage on receipt of 200.
+    """
+    try:
+        supabase.auth.sign_out()
+    except Exception as e:
+        # Non-fatal — token may already be expired
+        pass
+
+    return {"message": "Logged out successfully."}

--- a/backend/routers/evening.py
+++ b/backend/routers/evening.py
@@ -1,0 +1,241 @@
+"""
+routers/evening.py
+-------------------
+POST /evening-response — Two-step evening journal flow.
+
+Step 1 ("generate_questions"): Look up morning session → generate 3 AI questions
+Step 2 ("submit_answers"):     Save answers → generate AI reframe → check for crisis
+
+── BIDHUR (Frontend Contract) ────────────────────────────────────────
+STEP 1 — Open the evening journal screen:
+  POST /evening-response
+  Headers: { Authorization: Bearer <token> }
+  Body: {
+    "step": "generate_questions",
+    "morning_session_id": "<uuid from morning response>"
+  }
+  Response 200: {
+    "evening_session_id": string,  // ← SAVE THIS for Step 2
+    "questions": {
+      "q1": string,
+      "q2": string,
+      "q3": string
+    }
+  }
+
+STEP 2 — After user completes all 3 questions:
+  POST /evening-response
+  Headers: { Authorization: Bearer <token> }
+  Body: {
+    "step": "submit_answers",
+    "evening_session_id": "<uuid from Step 1>",
+    "q1_answer": string,
+    "q2_answer": string,
+    "q3_answer": string
+  }
+  Response 200: {
+    "reframe_response": {
+      "acknowledgment": string,
+      "insight":        string,
+      "invitation":     string
+    },
+    "crisis_detected": boolean   // ← if true, show crisis help resources immediately
+  }
+
+If crisis_detected is true, show the crisis resources screen before anything else.
+──────────────────────────────────────────────────────────────────────
+"""
+
+import json
+from fastapi import APIRouter, HTTPException, Depends, status
+from models.evening import (
+    GenerateQuestionsRequest,
+    GenerateQuestionsResponse,
+    EveningQuestions,
+    SubmitAnswersRequest,
+    SubmitAnswersResponse,
+    ReframeResponse,
+)
+from services.supabase_client import supabase_admin
+from services.groq_client import generate_evening_questions, generate_reframe_response
+from utils.auth_middleware import get_current_user
+from typing import Union
+
+router = APIRouter(tags=["Evening Journal"])
+
+
+@router.post(
+    "/evening-response",
+    status_code=status.HTTP_200_OK,
+)
+async def evening_response(
+    data: Union[GenerateQuestionsRequest, SubmitAnswersRequest],
+    user_id: str = Depends(get_current_user),
+):
+    """
+    Handles both steps of the evening journal flow.
+    The 'step' field in the request body determines which path to execute.
+    """
+
+    if isinstance(data, GenerateQuestionsRequest):
+        return await _step1_generate_questions(data, user_id)
+    else:
+        return await _step2_submit_answers(data, user_id)
+
+
+# ── STEP 1 ─────────────────────────────────────────────────
+
+async def _step1_generate_questions(
+    data: GenerateQuestionsRequest,
+    user_id: str,
+) -> GenerateQuestionsResponse:
+    """
+    Look up the morning session, call Groq to generate 3 questions,
+    create an evening_sessions row (partial — no answers yet),
+    and return the questions to the frontend.
+    """
+
+    # 1a. Fetch the morning session to get context for question generation
+    try:
+        morning_result = supabase_admin.table("morning_sessions")\
+            .select("*")\
+            .eq("id", data.morning_session_id)\
+            .eq("user_id", user_id)\
+            .single()\
+            .execute()
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Morning session not found: {str(e)}",
+        )
+
+    if not morning_result.data:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Morning session not found or does not belong to this user.",
+        )
+
+    morning = morning_result.data
+
+    # 1b. Call Groq to generate 3 personalized questions
+    # Sujan's prompt logic is isolated inside groq_client.py
+    try:
+        questions = await generate_evening_questions(
+            state_flag=morning["state_flag"],
+            event_tag=morning["event_tag"],
+            open_text=morning.get("open_text"),
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Failed to generate questions from AI: {str(e)}",
+        )
+
+    # 1c. Insert a partial evening_session row (answers filled in Step 2)
+    try:
+        evening_result = supabase_admin.table("evening_sessions").insert({
+            "user_id":             user_id,
+            "morning_session_id":  data.morning_session_id,
+            "q1_question":         questions["q1"],
+            "q2_question":         questions["q2"],
+            "q3_question":         questions["q3"],
+            # Answers left null — populated in Step 2
+        }).execute()
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to create evening session: {str(e)}",
+        )
+
+    evening_session_id = evening_result.data[0]["id"]
+
+    return GenerateQuestionsResponse(
+        evening_session_id=evening_session_id,
+        questions=EveningQuestions(
+            q1=questions["q1"],
+            q2=questions["q2"],
+            q3=questions["q3"],
+        ),
+    )
+
+
+# ── STEP 2 ─────────────────────────────────────────────────
+
+async def _step2_submit_answers(
+    data: SubmitAnswersRequest,
+    user_id: str,
+) -> SubmitAnswersResponse:
+    """
+    Save all 3 answers, send full journal context to Groq for reframing,
+    check for crisis signals, update the evening_session row, and return
+    the 3-part reframe response.
+    """
+
+    # 2a. Fetch the evening session (we need the questions + morning context)
+    try:
+        evening_result = supabase_admin.table("evening_sessions")\
+            .select("*, morning_sessions(state_flag, open_text)")\
+            .eq("id", data.evening_session_id)\
+            .eq("user_id", user_id)\
+            .single()\
+            .execute()
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Evening session not found: {str(e)}",
+        )
+
+    if not evening_result.data:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Evening session not found or does not belong to this user.",
+        )
+
+    session = evening_result.data
+    morning_context = session.get("morning_sessions", {}) or {}
+
+    # 2b. Call Groq for the AI reframe response
+    try:
+        reframe = await generate_reframe_response(
+            state_flag=morning_context.get("state_flag", "STABLE"),
+            open_text=morning_context.get("open_text"),
+            q1=session["q1_question"], a1=data.q1_answer,
+            q2=session["q2_question"], a2=data.q2_answer,
+            q3=session["q3_question"], a3=data.q3_answer,
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Failed to generate reframe from AI: {str(e)}",
+        )
+
+    crisis_detected: bool = reframe.get("crisis_detected", False)
+
+    # 2c. Update the evening_session row with answers + reframe
+    try:
+        supabase_admin.table("evening_sessions").update({
+            "q1_answer":            data.q1_answer,
+            "q2_answer":            data.q2_answer,
+            "q3_answer":            data.q3_answer,
+            # Store the full reframe as a JSON string for the RAG pipeline
+            "ai_reframe_response":  json.dumps({
+                "acknowledgment": reframe.get("acknowledgment", ""),
+                "insight":        reframe.get("insight", ""),
+                "invitation":     reframe.get("invitation", ""),
+            }),
+            "crisis_detected":      crisis_detected,
+        }).eq("id", data.evening_session_id).execute()
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to save answers: {str(e)}",
+        )
+
+    return SubmitAnswersResponse(
+        reframe_response=ReframeResponse(
+            acknowledgment=reframe.get("acknowledgment", ""),
+            insight=reframe.get("insight", ""),
+            invitation=reframe.get("invitation", ""),
+        ),
+        crisis_detected=crisis_detected,
+    )

--- a/backend/routers/morning.py
+++ b/backend/routers/morning.py
@@ -1,0 +1,109 @@
+"""
+routers/morning.py
+-------------------
+POST /morning-checkin — Submit daily morning brain scan.
+
+Processes slider scores → classifies state → saves to Supabase.
+
+── BIDHUR (Frontend Contract) ────────────────────────────────────────
+Request:
+  POST /morning-checkin
+  Headers: { Authorization: Bearer <token> }
+  Body: {
+    "sleep_score":   number,   // 0–10
+    "mood_score":    number,   // 0–10
+    "stress_score":  number,   // 0–10
+    "exercise_done": boolean,  // default false
+    "open_text":     string    // optional, null if empty
+  }
+
+Response 201: {
+  "morning_session_id": string,  // ← SAVE THIS. Send it to evening endpoint.
+  "state_flag": string,
+  "event_tag":  string,
+  "message":    string
+}
+
+Store morning_session_id in your component state so the evening
+journal screen can send it in the /evening-response request.
+──────────────────────────────────────────────────────────────────────
+"""
+
+from fastapi import APIRouter, HTTPException, Depends, status
+from models.morning import MorningCheckinRequest, MorningCheckinResponse
+from services.supabase_client import supabase_admin
+from services.state_classifier import classify_state
+from utils.auth_middleware import get_current_user
+
+router = APIRouter(tags=["Morning Check-In"])
+
+
+@router.post(
+    "/morning-checkin",
+    response_model=MorningCheckinResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def morning_checkin(
+    data: MorningCheckinRequest,
+    user_id: str = Depends(get_current_user),
+):
+    """
+    Submit the user's morning brain scan.
+
+    Processing steps:
+    1. Validate all slider scores (Pydantic handles 0–10 range)
+    2. Run classify_state() → state_flag + event_tag (pure function, no DB)
+    3. Insert one row into morning_sessions table
+    4. Return session ID + classification
+
+    The state_flag and event_tag are used by Sujan's prompt engine
+    in the evening session to generate personalized questions.
+    """
+
+    # Step 1 — Classify state (pure function, no DB involved)
+    classification = classify_state(
+        sleep=data.sleep_score,
+        mood=data.mood_score,
+        stress=data.stress_score,
+        exercise=data.exercise_done,
+        open_text=data.open_text,
+    )
+
+    state_flag = classification["state_flag"]
+    event_tag = classification["event_tag"]
+
+    # Step 2 — Insert into Supabase morning_sessions table
+    # We use supabase_admin here so the insert bypasses RLS while still
+    # tagging the row with the correct user_id from the JWT.
+    try:
+        result = supabase_admin.table("morning_sessions").insert({
+            "user_id":       user_id,
+            "sleep_score":   data.sleep_score,
+            "mood_score":    data.mood_score,
+            "stress_score":  data.stress_score,
+            "exercise_done": data.exercise_done,
+            "open_text":     data.open_text,
+            "state_flag":    state_flag,
+            "event_tag":     event_tag,
+        }).execute()
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to save morning check-in: {str(e)}",
+        )
+
+    # Extract the UUID of the newly created row
+    if not result.data:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Morning session was not saved. Please try again.",
+        )
+
+    morning_session_id = result.data[0]["id"]
+
+    return MorningCheckinResponse(
+        morning_session_id=morning_session_id,
+        state_flag=state_flag,
+        event_tag=event_tag,
+        message="Morning check-in recorded. See you this evening.",
+    )

--- a/backend/routers/weekly.py
+++ b/backend/routers/weekly.py
@@ -1,0 +1,158 @@
+"""
+routers/weekly.py
+------------------
+GET /weekly-summary — AI-generated weekly mental health theme summary.
+
+Fetches last 7 evening sessions, extracts journal text, sends to Groq,
+runs detect_trend() on morning scores, and returns the full weekly report.
+
+── BIDHUR (Frontend Contract) ────────────────────────────────────────
+Request:
+  GET /weekly-summary
+  Headers: { Authorization: Bearer <token> }
+  No body or query params needed — user_id comes from the JWT.
+
+Response 200: {
+  "week_summary": string,    // 2–3 sentence AI paragraph
+  "trend":        "IMPROVING" | "DECLINING" | "FLAT",
+  "days_logged":  number,    // how many days had sessions this week
+  "average_scores": {
+    "mood":   number,
+    "sleep":  number,
+    "stress": number
+  }
+}
+
+── DANISH (Adaptive Engine) ───────────────────────────────────────────
+The "trend" field in the response is computed by detect_trend() from
+services/state_classifier.py. You can also call detect_trend() directly
+from your adaptive engine using the morning_sessions data.
+
+Direct Supabase query for your adaptive engine:
+  SELECT sleep_score, mood_score, stress_score, created_at
+  FROM morning_sessions
+  WHERE user_id = '<uuid>'
+  ORDER BY created_at DESC
+  LIMIT 7;
+──────────────────────────────────────────────────────────────────────
+"""
+
+from fastapi import APIRouter, HTTPException, Depends, status
+from models.weekly import WeeklySummaryResponse, AverageScores
+from services.supabase_client import supabase_admin
+from services.state_classifier import detect_trend
+from services.groq_client import generate_weekly_summary
+from utils.auth_middleware import get_current_user
+
+router = APIRouter(tags=["Weekly Summary"])
+
+
+@router.get(
+    "/weekly-summary",
+    response_model=WeeklySummaryResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def weekly_summary(user_id: str = Depends(get_current_user)):
+    """
+    Generate a weekly mental health summary for the authenticated user.
+
+    Steps:
+    1. Fetch last 7 evening_sessions (with linked morning_sessions)
+    2. Build a journal context string for the Groq prompt
+    3. Call Groq to generate a 2–3 sentence summary paragraph
+    4. Run detect_trend() on the 7 morning scores
+    5. Compute average scores
+    6. Return everything to the frontend
+    """
+
+    # Step 1 — Fetch last 7 evening sessions with morning context
+    try:
+        result = supabase_admin\
+            .table("evening_sessions")\
+            .select("q1_question, q1_answer, q2_question, q2_answer, q3_question, q3_answer, morning_sessions(sleep_score, mood_score, stress_score, state_flag)")\
+            .eq("user_id", user_id)\
+            .order("created_at", desc=True)\
+            .limit(7)\
+            .execute()
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to fetch sessions: {str(e)}",
+        )
+
+    sessions = result.data or []
+    days_logged = len(sessions)
+
+    if days_logged == 0:
+        # No sessions yet — return a friendly empty state
+        return WeeklySummaryResponse(
+            week_summary="No journal entries found yet. Complete your first evening session to begin tracking.",
+            trend="FLAT",
+            days_logged=0,
+            average_scores=AverageScores(mood=0.0, sleep=0.0, stress=0.0),
+        )
+
+    # Step 2 — Build journal context string for Groq prompt
+    # Format: "Day 1 - Q: <question> A: <answer> ..."
+    journal_lines = []
+    morning_scores = []
+    state_flags = []
+
+    for i, session in enumerate(sessions):
+        morning = session.get("morning_sessions") or {}
+
+        # Collect morning scores for trend detection
+        if morning:
+            morning_scores.append({
+                "mood_score":   morning.get("mood_score", 5),
+                "sleep_score":  morning.get("sleep_score", 5),
+                "stress_score": morning.get("stress_score", 5),
+            })
+            state_flags.append(morning.get("state_flag", "STABLE"))
+
+        # Build journal text block for this day
+        day_text = f"--- Day {i + 1} ---\n"
+        for q_num in range(1, 4):
+            q_key = f"q{q_num}_question"
+            a_key = f"q{q_num}_answer"
+            question = session.get(q_key, "")
+            answer = session.get(a_key, "") or "[no answer]"
+            if question:
+                day_text += f"Q: {question}\nA: {answer}\n"
+
+        journal_lines.append(day_text)
+
+    journal_context = "\n".join(journal_lines)
+
+    # Step 3 — Call Groq for the weekly summary paragraph
+    try:
+        week_summary = await generate_weekly_summary(
+            journal_context=journal_context,
+            state_flags=state_flags,
+        )
+    except Exception as e:
+        # Non-fatal — return data without AI summary rather than 500
+        week_summary = "Unable to generate AI summary at this time. Your data has been recorded."
+
+    # Step 4 — Compute trend from morning scores
+    # detect_trend() expects oldest-first; our query returns newest-first
+    trend = detect_trend(list(reversed(morning_scores)))
+
+    # Step 5 — Compute average scores
+    if morning_scores:
+        avg_mood  = round(sum(s["mood_score"]  for s in morning_scores) / len(morning_scores), 1)
+        avg_sleep = round(sum(s["sleep_score"] for s in morning_scores) / len(morning_scores), 1)
+        avg_stress = round(sum(s["stress_score"] for s in morning_scores) / len(morning_scores), 1)
+    else:
+        avg_mood = avg_sleep = avg_stress = 0.0
+
+    return WeeklySummaryResponse(
+        week_summary=week_summary,
+        trend=trend,
+        days_logged=days_logged,
+        average_scores=AverageScores(
+            mood=avg_mood,
+            sleep=avg_sleep,
+            stress=avg_stress,
+        ),
+    )

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,0 +1,1 @@
+# services package

--- a/backend/services/groq_client.py
+++ b/backend/services/groq_client.py
@@ -1,0 +1,167 @@
+"""
+services/groq_client.py
+------------------------
+Groq API wrapper for all LLM calls in MindProtocol.
+
+⚠️  SUJAN: This file is your domain. Nishant has set up the
+    scaffolding and the function signatures. Replace each stub's
+    return value with a real Groq API call + your system prompt.
+
+    The function signatures and return types are FROZEN — do not
+    change them, or the routers that call them will break.
+
+All functions are async to keep FastAPI non-blocking.
+"""
+
+import os
+import json
+from groq import AsyncGroq
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Initialize the async Groq client once at import time
+_groq_client = AsyncGroq(api_key=os.environ.get("GROQ_API_KEY", ""))
+
+# Model to use — llama-3.3-70b-versatile is on the free Groq tier
+GROQ_MODEL = "llama-3.3-70b-versatile"
+
+
+# ──────────────────────────────────────────────────────────
+# 1. GENERATE EVENING QUESTIONS
+# Called by: routers/evening.py → step="generate_questions"
+# ──────────────────────────────────────────────────────────
+
+async def generate_evening_questions(
+    state_flag: str,
+    event_tag: str,
+    open_text: str | None,
+) -> dict:
+    """
+    Generate 3 personalized evening reflection questions based on the
+    user's morning check-in state.
+
+    Parameters
+    ----------
+    state_flag : "HIGH_REACTIVITY" | "LOW_BASELINE" | "PHYSICAL_DEPLETION" | "STABLE"
+    event_tag  : "EVENT_TRIGGER" | "GENERAL_STATE"
+    open_text  : The user's optional morning free-text (may be None)
+
+    Returns
+    -------
+    dict with keys "q1", "q2", "q3" — each a question string.
+
+    SUJAN: Replace the stub below with your Groq call.
+    Your system prompt should instruct the model to:
+      - Use state_flag to calibrate emotional depth
+      - Use event_tag to decide if questions reference open_text
+      - Return ONLY valid JSON: {"q1": "...", "q2": "...", "q3": "..."}
+      - Avoid clinical language; use warm, curious tone
+    """
+
+    # ── SUJAN: Replace this stub with your real Groq call ──
+    # Example structure for your implementation:
+    #
+    # system_prompt = f"""You are a compassionate mental health reflection guide...
+    #   State: {state_flag}
+    #   Event context: {open_text or 'none'}
+    #   Return ONLY JSON: {{"q1": "...", "q2": "...", "q3": "..."}}
+    # """
+    # response = await _groq_client.chat.completions.create(
+    #     model=GROQ_MODEL,
+    #     messages=[{"role": "system", "content": system_prompt},
+    #               {"role": "user", "content": "Generate the 3 questions now."}],
+    #     temperature=0.7,
+    #     max_tokens=300,
+    # )
+    # return json.loads(response.choices[0].message.content)
+
+    # Stub response so the endpoint works before Sujan wires the LLM
+    return {
+        "q1": f"[STUB] How did today unfold for you? (state: {state_flag})",
+        "q2": "[STUB] What was the most significant moment of your day?",
+        "q3": "[STUB] What would you like to carry forward into tomorrow?",
+    }
+
+
+# ──────────────────────────────────────────────────────────
+# 2. GENERATE AI REFRAME RESPONSE
+# Called by: routers/evening.py → step="submit_answers"
+# ──────────────────────────────────────────────────────────
+
+async def generate_reframe_response(
+    state_flag: str,
+    open_text: str | None,
+    q1: str, a1: str,
+    q2: str, a2: str,
+    q3: str, a3: str,
+) -> dict:
+    """
+    Generate a 3-part AI reframe response after the user completes
+    all 3 evening journal questions.
+
+    Parameters
+    ----------
+    state_flag : morning state flag (for emotional calibration)
+    open_text  : morning free-text context
+    q1..q3     : the three AI-generated questions
+    a1..a3     : the user's answers to each question
+
+    Returns
+    -------
+    dict with keys:
+      "acknowledgment" : validates the user's experience (1–2 sentences)
+      "insight"        : gentle reframe or observation (1–2 sentences)
+      "invitation"     : a micro-action or intention for tomorrow (1 sentence)
+      "crisis_detected": bool — True if any answer signals self-harm risk
+
+    SUJAN: Replace the stub below with your Groq call.
+    Your system prompt must:
+      - Instruct the model to detect crisis signals (self-harm, hopelessness)
+      - Return ONLY valid JSON matching the dict structure above
+      - Never be preachy — warm, specific, and grounded in the user's words
+    """
+
+    # ── SUJAN: Replace this stub ──
+    # response = await _groq_client.chat.completions.create(...)
+    # parsed = json.loads(response.choices[0].message.content)
+    # return parsed
+
+    return {
+        "acknowledgment": "[STUB] You showed up for yourself today — that matters.",
+        "insight": "[STUB] The pattern you described suggests growing self-awareness.",
+        "invitation": "[STUB] Tomorrow, notice one moment where you feel genuinely at ease.",
+        "crisis_detected": False,
+    }
+
+
+# ──────────────────────────────────────────────────────────
+# 3. GENERATE WEEKLY SUMMARY
+# Called by: routers/weekly.py
+# ──────────────────────────────────────────────────────────
+
+async def generate_weekly_summary(journal_context: str, state_flags: list[str]) -> str:
+    """
+    Generate a 2–3 sentence paragraph summarizing recurring themes
+    across the user's past 7 evening journal sessions.
+
+    Parameters
+    ----------
+    journal_context : All Q&A text from the week, concatenated and
+                      formatted for the prompt. Nishant builds this string.
+    state_flags     : List of state_flag strings from each morning session
+                      e.g. ["STABLE", "HIGH_REACTIVITY", "STABLE", ...]
+
+    Returns
+    -------
+    str — A warm, observational paragraph (not clinical, not preachy).
+
+    SUJAN: Replace the stub below with your Groq call.
+    """
+
+    # ── SUJAN: Replace this stub ──
+    return (
+        "[STUB] This week, your journals reveal a recurring theme of "
+        "navigating pressure with resilience. You consistently returned "
+        "to reflection even on difficult days — that consistency is the practice."
+    )

--- a/backend/services/state_classifier.py
+++ b/backend/services/state_classifier.py
@@ -1,0 +1,171 @@
+"""
+services/state_classifier.py
+-----------------------------
+Pure ML/logic functions for MindProtocol.
+
+Contains:
+  1. classify_state()  — Translates morning slider scores into a
+                         state_flag + event_tag. No DB calls.
+                         Called by the /morning-checkin endpoint.
+
+  2. detect_trend()    — Takes 7 days of morning scores and returns
+                         IMPROVING / DECLINING / FLAT.
+                         Used by Danish's adaptive engine and the
+                         /weekly-summary endpoint.
+
+All functions are pure (no side effects, no I/O) so they are easy
+to unit test independently of the database.
+
+Owner: Nishant
+Danish: detect_trend() is yours to call from the adaptive engine.
+"""
+
+from typing import Optional
+
+
+# ──────────────────────────────────────────────
+# 1. STATE CLASSIFICATION
+# ──────────────────────────────────────────────
+
+def classify_state(
+    sleep: int,
+    mood: int,
+    stress: int,
+    exercise: bool,
+    open_text: Optional[str],
+) -> dict:
+    """
+    Translate morning slider scores into a state flag and event tag.
+
+    Parameters
+    ----------
+    sleep     : int  — Sleep quality score 0–10
+    mood      : int  — Mood score 0–10
+    stress    : int  — Stress level 0–10
+    exercise  : bool — Whether the user exercised this morning
+    open_text : str  — Optional free-text from the morning check-in
+
+    Returns
+    -------
+    dict with keys:
+      "state_flag"  : "HIGH_REACTIVITY" | "LOW_BASELINE" |
+                      "PHYSICAL_DEPLETION" | "STABLE"
+      "event_tag"   : "EVENT_TRIGGER" | "GENERAL_STATE"
+
+    Rules (evaluated in priority order — first match wins)
+    -------------------------------------------------------
+    HIGH_REACTIVITY:
+        stress >= 7 AND mood <= 4
+        OR stress >= 8 (regardless of mood)
+
+    PHYSICAL_DEPLETION:
+        sleep <= 3
+        OR (sleep <= 5 AND NOT exercise AND mood <= 5)
+
+    LOW_BASELINE:
+        mood <= 3
+        OR (mood <= 4 AND sleep <= 5 AND stress >= 6)
+
+    STABLE:
+        Everything else (ideal: mood >= 6, stress <= 6, sleep >= 5)
+    """
+
+    # ── State Flag ───────────────────────────────────────────
+    state_flag: str
+
+    if (stress >= 7 and mood <= 4) or stress >= 8:
+        # High stress is dominating — reactivity is elevated.
+        # The person is likely in fight-or-flight mode.
+        state_flag = "HIGH_REACTIVITY"
+
+    elif sleep <= 3 or (sleep <= 5 and not exercise and mood <= 5):
+        # Physical/recovery deficit. Questions should focus on rest
+        # and gentle self-care rather than cognitive reframing.
+        state_flag = "PHYSICAL_DEPLETION"
+
+    elif mood <= 3 or (mood <= 4 and sleep <= 5 and stress >= 6):
+        # Low mood is the primary signal. Requires compassionate,
+        # non-challenging evening questions.
+        state_flag = "LOW_BASELINE"
+
+    else:
+        # User is in a functional baseline. Reflective questions
+        # can be more nuanced and growth-oriented.
+        state_flag = "STABLE"
+
+    # ── Event Tag ────────────────────────────────────────────
+    # If the user typed a meaningful note, the evening questions
+    # should be anchored to that specific event/context.
+    event_tag: str
+
+    if open_text is not None and len(open_text.strip()) > 10:
+        event_tag = "EVENT_TRIGGER"
+    else:
+        event_tag = "GENERAL_STATE"
+
+    return {"state_flag": state_flag, "event_tag": event_tag}
+
+
+# ──────────────────────────────────────────────
+# 2. WEEKLY TREND DETECTION
+# Danish: call this function from your adaptive engine.
+# ──────────────────────────────────────────────
+
+def detect_trend(scores_7_days: list[dict]) -> str:
+    """
+    Detect whether a user's mental health is IMPROVING, DECLINING, or FLAT
+    over the past 7 days.
+
+    Parameters
+    ----------
+    scores_7_days : list of dicts, each containing:
+        {
+          "mood_score":   int,   # 0–10
+          "sleep_score":  int,   # 0–10
+          "stress_score": int    # 0–10 (higher = worse)
+        }
+        Expected order: oldest first, most recent last.
+        If fewer than 6 days are provided, return "FLAT" (not enough data).
+
+    Returns
+    -------
+    "IMPROVING" | "DECLINING" | "FLAT"
+
+    Algorithm
+    ---------
+    1. Compute a composite_score per day:
+           composite = (mood + sleep + (10 - stress)) / 3
+       Stress is inverted so that higher composite = better wellbeing.
+    2. Compare average of FIRST 3 days vs average of LAST 3 days.
+    3. If (last_avg - first_avg) > +1.0  → IMPROVING
+       If (last_avg - first_avg) < -1.0  → DECLINING
+       Otherwise                         → FLAT
+
+    Danish: you can pass the result of this function directly to the
+    chart color logic — green=IMPROVING, yellow=FLAT, red=DECLINING.
+    """
+
+    # Need at least 6 data points for a meaningful comparison
+    if len(scores_7_days) < 6:
+        return "FLAT"
+
+    def composite(day: dict) -> float:
+        """Single-day wellbeing composite score (0–10 range)."""
+        mood  = day.get("mood_score", 5)
+        sleep = day.get("sleep_score", 5)
+        stress = day.get("stress_score", 5)
+        return (mood + sleep + (10 - stress)) / 3
+
+    composites = [composite(day) for day in scores_7_days]
+
+    # Use the first 3 and last 3 days for comparison
+    first_avg = sum(composites[:3]) / 3
+    last_avg  = sum(composites[-3:]) / 3
+    diff = last_avg - first_avg
+
+    if diff > 1.0:
+        return "IMPROVING"
+    elif diff < -1.0:
+        return "DECLINING"
+    else:
+        return "FLAT"

--- a/backend/services/supabase_client.py
+++ b/backend/services/supabase_client.py
@@ -1,0 +1,43 @@
+"""
+services/supabase_client.py
+---------------------------
+Singleton Supabase client used across all routers.
+
+Two clients are exposed:
+  - supabase_anon   : uses ANON key — for user-authenticated requests
+  - supabase_admin  : uses SERVICE_ROLE key — for server-side ops like
+                      creating profiles, reading other users' data (avoid
+                      unless necessary). Never expose this key to the frontend.
+"""
+
+import os
+from supabase import create_client, Client
+from dotenv import load_dotenv
+
+load_dotenv()
+
+SUPABASE_URL: str = os.environ["SUPABASE_URL"]
+SUPABASE_ANON_KEY: str = os.environ["SUPABASE_ANON_KEY"]
+SUPABASE_SERVICE_ROLE_KEY: str = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
+
+
+def get_supabase_client() -> Client:
+    """
+    Returns a Supabase client initialized with the anon key.
+    Used for all user-authenticated requests — RLS policies apply.
+    """
+    return create_client(SUPABASE_URL, SUPABASE_ANON_KEY)
+
+
+def get_supabase_admin_client() -> Client:
+    """
+    Returns a Supabase client initialized with the service role key.
+    BYPASSES Row Level Security — use only for trusted server-side ops.
+    Never expose the service role key to the frontend.
+    """
+    return create_client(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+
+
+# Singleton instances — import these directly in routers/services
+supabase: Client = get_supabase_client()
+supabase_admin: Client = get_supabase_admin_client()

--- a/backend/supabase_schema.sql
+++ b/backend/supabase_schema.sql
@@ -1,0 +1,162 @@
+-- ============================================================
+-- MindProtocol — Supabase Schema
+-- Run this entire file in the Supabase SQL Editor (once)
+-- Project: Nepal-US Hackathon 2026
+-- Owner: Nishant (Backend & Database)
+-- ============================================================
+
+-- Enable pgvector for journal embeddings (Sujan's RAG pipeline)
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- ============================================================
+-- TABLE 1: profiles
+-- Auto-created on signup via trigger below.
+-- Extends auth.users with a display username.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.profiles (
+    id          UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    username    TEXT NOT NULL,
+    created_at  TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- RLS: each user can only see and edit their own profile
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "profiles_select_own" ON public.profiles
+    FOR SELECT USING (auth.uid() = id);
+
+CREATE POLICY "profiles_update_own" ON public.profiles
+    FOR UPDATE USING (auth.uid() = id);
+
+-- Trigger: auto-insert a profile row whenever a new user signs up
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+    INSERT INTO public.profiles (id, username)
+    VALUES (
+        NEW.id,
+        COALESCE(NEW.raw_user_meta_data->>'username', split_part(NEW.email, '@', 1))
+    );
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+    AFTER INSERT ON auth.users
+    FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- ============================================================
+-- TABLE 2: morning_sessions
+-- One row per morning check-in submission.
+-- state_flag and event_tag are computed by state_classifier.py
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.morning_sessions (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id       UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    sleep_score   INTEGER NOT NULL CHECK (sleep_score BETWEEN 0 AND 10),
+    mood_score    INTEGER NOT NULL CHECK (mood_score BETWEEN 0 AND 10),
+    stress_score  INTEGER NOT NULL CHECK (stress_score BETWEEN 0 AND 10),
+    exercise_done BOOLEAN DEFAULT FALSE,
+    open_text     TEXT,
+    -- Computed by Nishant's state_classifier.py before insert
+    state_flag    TEXT NOT NULL CHECK (state_flag IN ('HIGH_REACTIVITY', 'LOW_BASELINE', 'PHYSICAL_DEPLETION', 'STABLE')),
+    event_tag     TEXT NOT NULL CHECK (event_tag IN ('EVENT_TRIGGER', 'GENERAL_STATE')),
+    created_at    TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Index for fast lookup of a user's recent sessions (Danish's trend query)
+CREATE INDEX IF NOT EXISTS idx_morning_sessions_user_created
+    ON public.morning_sessions(user_id, created_at DESC);
+
+-- RLS: users can only read/write their own morning sessions
+ALTER TABLE public.morning_sessions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "morning_sessions_insert_own" ON public.morning_sessions
+    FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "morning_sessions_select_own" ON public.morning_sessions
+    FOR SELECT USING (auth.uid() = user_id);
+
+-- ============================================================
+-- TABLE 3: evening_sessions
+-- Linked to a morning_session. Stores 3 AI questions + user
+-- answers + the final AI reframe response.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.evening_sessions (
+    id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id              UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    morning_session_id   UUID NOT NULL REFERENCES public.morning_sessions(id) ON DELETE CASCADE,
+    -- AI-generated questions (set in step 1 of /evening-response)
+    q1_question          TEXT NOT NULL,
+    q2_question          TEXT NOT NULL,
+    q3_question          TEXT NOT NULL,
+    -- User answers (set in step 2 of /evening-response)
+    q1_answer            TEXT,
+    q2_answer            TEXT,
+    q3_answer            TEXT,
+    -- AI reframe response fields (set after step 2)
+    ai_reframe_response  TEXT,         -- Full JSON string of the 3-part reframe
+    crisis_detected      BOOLEAN DEFAULT FALSE,
+    created_at           TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Index for fast weekly lookups
+CREATE INDEX IF NOT EXISTS idx_evening_sessions_user_created
+    ON public.evening_sessions(user_id, created_at DESC);
+
+-- RLS
+ALTER TABLE public.evening_sessions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "evening_sessions_insert_own" ON public.evening_sessions
+    FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "evening_sessions_select_own" ON public.evening_sessions
+    FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "evening_sessions_update_own" ON public.evening_sessions
+    FOR UPDATE USING (auth.uid() = user_id);
+
+-- ============================================================
+-- TABLE 4: journal_embeddings
+-- Sujan's RAG pipeline writes here. Stores HuggingFace
+-- all-MiniLM-L6-v2 embeddings (384 dimensions) for semantic
+-- retrieval of past journal entries.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.journal_embeddings (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id             UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    evening_session_id  UUID NOT NULL REFERENCES public.evening_sessions(id) ON DELETE CASCADE,
+    content             TEXT NOT NULL,      -- The journal text that was embedded
+    embedding           VECTOR(384),        -- HuggingFace all-MiniLM-L6-v2 output
+    created_at          TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- ivfflat index for fast approximate nearest-neighbor search
+-- Sujan: use this for "find past journal entries similar to tonight's"
+CREATE INDEX IF NOT EXISTS idx_journal_embeddings_vector
+    ON public.journal_embeddings USING ivfflat (embedding vector_cosine_ops)
+    WITH (lists = 100);
+
+CREATE INDEX IF NOT EXISTS idx_journal_embeddings_user
+    ON public.journal_embeddings(user_id);
+
+-- RLS
+ALTER TABLE public.journal_embeddings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "journal_embeddings_insert_own" ON public.journal_embeddings
+    FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "journal_embeddings_select_own" ON public.journal_embeddings
+    FOR SELECT USING (auth.uid() = user_id);
+
+-- ============================================================
+-- DANISH'S TREND QUERY (documented here for his reference)
+-- Run this in your adaptive engine to get last 7 morning scores:
+--
+-- SELECT sleep_score, mood_score, stress_score, created_at
+-- FROM public.morning_sessions
+-- WHERE user_id = '<user_uuid>'
+-- ORDER BY created_at DESC
+-- LIMIT 7;
+-- ============================================================

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -1,0 +1,1 @@
+# utils package

--- a/backend/utils/auth_middleware.py
+++ b/backend/utils/auth_middleware.py
@@ -1,0 +1,74 @@
+"""
+utils/auth_middleware.py
+-------------------------
+FastAPI dependency for JWT authentication via Supabase Auth.
+
+Usage in any protected endpoint:
+    from utils.auth_middleware import get_current_user
+
+    @router.post("/some-protected-route")
+    async def handler(data: SomeModel, user_id: str = Depends(get_current_user)):
+        # user_id is the authenticated user's UUID
+        ...
+
+The JWT is issued by Supabase when a user logs in. It is verified
+here using the SUPABASE_JWT_SECRET from the .env file.
+"""
+
+import os
+from fastapi import HTTPException, Security, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError, jwt
+from dotenv import load_dotenv
+
+load_dotenv()
+
+SUPABASE_JWT_SECRET: str = os.environ.get("SUPABASE_JWT_SECRET", "")
+
+# HTTPBearer auto-extracts the token from "Authorization: Bearer <token>"
+_bearer_scheme = HTTPBearer()
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Security(_bearer_scheme),
+) -> str:
+    """
+    FastAPI dependency that validates a Supabase JWT and returns the user_id.
+
+    Raises
+    ------
+    HTTPException 401 — if the token is missing, expired, or has an invalid signature.
+    HTTPException 401 — if the token does not contain a 'sub' claim (user_id).
+
+    Returns
+    -------
+    str — The authenticated user's UUID (from the 'sub' JWT claim).
+    """
+
+    token = credentials.credentials  # Raw JWT string
+
+    try:
+        payload = jwt.decode(
+            token,
+            SUPABASE_JWT_SECRET,
+            algorithms=["HS256"],
+            # Supabase JWTs use "authenticated" as the audience
+            options={"verify_aud": False},
+        )
+    except JWTError as e:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"Invalid or expired token: {str(e)}",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    user_id: str | None = payload.get("sub")
+
+    if not user_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token is missing the user identifier (sub claim).",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    return user_id


### PR DESCRIPTION
## What this PR does
Completes Issue #1 and Issue #2 for the MindProtocol backend.

### Issue #1 — FastAPI project setup + 3 endpoints
- [x] `POST /morning-checkin` — validates sliders, returns state_flag + placeholders
- [x] `POST /evening-response` — 2-step flow (generate questions → submit answers)
- [x] `GET /weekly-summary` — trend detection + weekly scores
- [x] `GET /health` — returns `{"status": "ok"}`
- [x] CORS middleware configured
- [x] All secrets loaded from `.env` via `python-dotenv`
- [x] `requirements.txt` with pinned versions

### Issue #2 — Supabase schema
- [x] `profiles` table with auto-trigger on signup
- [x] `morning_sessions` table with state_flag + event_tag
- [x] `evening_sessions` table with Q&A + AI reframe storage
- [x] `journal_embeddings` table with `VECTOR(384)` for RAG
- [x] `pgvector` extension enabled
- [x] RLS policies on all tables
- [x] `ivfflat` index for similarity search
- [x] `match_journals()` RPC function for Sujan's RAG pipeline

### How to test
```bash
pip install -r requirements.txt
cp .env.example .env   # fill in Supabase keys
uvicorn main:app --reload --port 8000
# Visit http://localhost:8000/docs
```

### Teammates — what you need from this PR
- **Sujan** → open `services/groq_client.py`, replace the 3 stubs with real prompts
- **Bidur** → frontend contracts documented at the top of each router file
- **Danish** → `detect_trend()` ready in `services/state_classifier.py`
- **Supabase screenshot** → run `supabase_schema.sql` and share table editor screenshot here

Closes #1
Closes #2
Closes #11